### PR TITLE
Refine Tiingo API redirects

### DIFF
--- a/_redirects
+++ b/_redirects
@@ -1,5 +1,7 @@
 # API routes must come first to avoid being caught by catch-all
-/api/*                  /.netlify/functions/:splat  200
+/api/tiingo             /.netlify/functions/tiingo   200
+/api/tiingo/*           /.netlify/functions/tiingo   200
+/api/*                  /.netlify/functions/:splat   200
 
 # Specific page routes
 /ai-analyst            /ai-analyst.html             200

--- a/netlify.toml
+++ b/netlify.toml
@@ -37,6 +37,16 @@
 
 # SPA + Functions routing
 [[redirects]]
+  from = "/api/tiingo"
+  to = "/.netlify/functions/tiingo"
+  status = 200
+
+[[redirects]]
+  from = "/api/tiingo/*"
+  to = "/.netlify/functions/tiingo"
+  status = 200
+
+[[redirects]]
   from = "/api/*"
   to = "/.netlify/functions/:splat"
   status = 200


### PR DESCRIPTION
## Summary
- add explicit Netlify redirect entries to route `/api/tiingo` traffic to the Tiingo function
- sync the `_redirects` file so static hosting and Netlify CLI honor the Tiingo function mapping

## Testing
- not run (config-only change)


------
https://chatgpt.com/codex/tasks/task_e_68d8e8eb806883299b2a6ca4e6c47c99