### PR TITLE
Remove hardcoded Tiingo API key from documentation

### DIFF
--- a/TIINGO_IMPLEMENTATION.md
+++ b/TIINGO_IMPLEMENTATION.md
@@ -26,9 +26,9 @@ TIINGO_ACCESS_KEY=your_api_key_here
 TIINGO_AUTH_TOKEN=your_api_key_here
 ```
 
-Add your API key to the `.env` file:
+Add your API key to the `.env` file (replace `your_real_key` with your actual secret value):
 ```bash
-TIINGO_KEY=aab69a760ed80b5c6c84a5a6f5e76423b3828b90
+TIINGO_KEY=your_real_key
 ```
 
 ## Implementation Options


### PR DESCRIPTION
## Summary
- replace the hardcoded Tiingo API key example in the implementation guide with a placeholder value
- clarify instructions for storing the secret in the local .env file

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d8ea2830c88329a129cb09f109f5e2