### PR TITLE
Relocate trading desk watchlist ahead of key stats

### DIFF
--- a/index.html
+++ b/index.html
@@ -65,6 +65,31 @@
       </div>
 
       <div class="card">
+        <div class="card-header">
+          <h3>Watchlist</h3>
+          <div class="exchange-filter">
+            <select id="exchangeFilters">
+              <option value="">All</option>
+              <option value="XNAS">NASDAQ</option>
+              <option value="XNYS">NYSE</option>
+              <option value="XASX">ASX</option>
+              <option value="XASE">AMEX</option>
+              <option value="XTSE">Toronto</option>
+              <option value="XLON">LSE</option>
+              <option value="XETR">XETRA</option>
+              <option value="XTKS">Tokyo</option>
+              <option value="XHKG">HKEX</option>
+            </select>
+          </div>
+        </div>
+        <div class="search-container">
+          <input type="text" id="stockSearchInput" placeholder="Search ticker, company, or ASX:WOW, WOW.AX…">
+          <div id="searchResults"></div>
+        </div>
+        <div id="watchlist" class="watchlist-container"></div>
+      </div>
+
+      <div class="card">
         <div class="card-header"><h3>Key Statistics</h3></div>
         <div class="stock-stats">
           <div class="stat-item"><div class="stat-item-label">Open</div><div id="statOpen" class="stat-item-value">—</div></div>
@@ -101,31 +126,6 @@
     </main>
 
     <aside class="sidebar">
-      <div class="card">
-        <div class="card-header">
-          <h3>Watchlist</h3>
-           <div class="exchange-filter">
-            <select id="exchangeFilters">
-              <option value="">All</option>
-              <option value="XNAS">NASDAQ</option>
-              <option value="XNYS">NYSE</option>
-              <option value="XASX">ASX</option>
-              <option value="XASE">AMEX</option>
-              <option value="XTSE">Toronto</option>
-              <option value="XLON">LSE</option>
-              <option value="XETR">XETRA</option>
-              <option value="XTKS">Tokyo</option>
-              <option value="XHKG">HKEX</option>
-            </select>
-          </div>
-        </div>
-        <div class="search-container">
-          <input type="text" id="stockSearchInput" placeholder="Search ticker, company, or ASX:WOW, WOW.AX…">
-          <div id="searchResults"></div>
-        </div>
-        <div id="watchlist" class="watchlist-container"></div>
-      </div>
-
       <div class="card">
         <div class="card-header"><h3>Financial News</h3></div>
         <div class="news-sources" id="newsApiButtons">


### PR DESCRIPTION
## Summary
- reposition the trading desk watchlist card into the main column above the Key Statistics panel
- keep existing watchlist controls and container intact so the Tiingo-powered data hooks continue working after the move

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d8f45dff888329b548abca23082bb0