### PR TITLE
Improve Tiingo CLI runner flexibility

### DIFF
--- a/TIINGO_IMPLEMENTATION.md
+++ b/TIINGO_IMPLEMENTATION.md
@@ -202,8 +202,8 @@ node simple-test-client.js
 # Test Netlify function locally (requires netlify dev)
 node test-tiingo.js
 
-# Test specific run
-node run-tiingo.mjs
+# Test specific run (supports symbol/kind arguments)
+node run-tiingo.mjs MSFT intraday --limit=20
 ```
 
 ## Frontend Integration

--- a/run-tiingo.mjs
+++ b/run-tiingo.mjs
@@ -1,9 +1,106 @@
 import handleTiingoRequest from './netlify/functions/tiingo.js';
 
-const req = new Request('http://localhost/api/tiingo?symbol=AAPL&kind=eod');
-const resp = await handleTiingoRequest(req);
-console.log('status', resp.status);
-const headers = {}; resp.headers.forEach((v,k)=> headers[k]=v);
-console.log('headers', headers);
-const text = await resp.text();
-console.log('body', text.slice(0,200)+'...');
+const DEFAULT_BASE = 'http://localhost';
+const DEFAULT_PATH = '/api/tiingo';
+const HELP_TEXT = `Usage: node run-tiingo.mjs [symbol] [kind] [options]\n\n` +
+  `Arguments:\n` +
+  `  symbol                Stock ticker symbol (default: AAPL)\n` +
+  `  kind                  Data kind (eod, intraday, news, etc. Default: eod)\n\n` +
+  `Options:\n` +
+  `  --limit=<n>           Limit number of results\n` +
+  `  --interval=<value>    Interval for intraday data (e.g. 1min)\n` +
+  `  --base=<url>          Base URL for the request (default: ${DEFAULT_BASE})\n` +
+  `  --path=<path>         Endpoint path (default: ${DEFAULT_PATH})\n` +
+  `  --raw                 Print raw response body\n` +
+  `  --help                Show this message\n\n` +
+  `Any additional --key=value pairs are appended as query parameters.`;
+
+function parseArgs(argv = []) {
+  const args = [...argv];
+  let symbol;
+  let kind;
+  const params = new URLSearchParams();
+  const options = { base: DEFAULT_BASE, path: DEFAULT_PATH, raw: false };
+
+  for (const arg of args) {
+    if (arg === '--help' || arg === '-h') {
+      return { help: true };
+    }
+
+    if (arg.startsWith('--')) {
+      const [flag, ...rest] = arg.slice(2).split('=');
+      const value = rest.length ? rest.join('=') : undefined;
+      if (flag === 'raw') {
+        options.raw = true;
+        continue;
+      }
+      if (flag === 'base' && value) {
+        options.base = value.replace(/\/?$/, '');
+        continue;
+      }
+      if (flag === 'path' && value) {
+        options.path = value.startsWith('/') ? value : `/${value}`;
+        continue;
+      }
+      if (value !== undefined) {
+        params.set(flag, value);
+        continue;
+      }
+      throw new Error(`Flag "--${flag}" requires a value.`);
+    }
+
+    if (!symbol) {
+      symbol = arg;
+    } else if (!kind) {
+      kind = arg;
+    } else {
+      throw new Error(`Unexpected argument: ${arg}`);
+    }
+  }
+
+  return {
+    symbol: (symbol || 'AAPL').toUpperCase(),
+    kind: (kind || 'eod').toLowerCase(),
+    params,
+    options,
+  };
+}
+
+const parsed = parseArgs(process.argv.slice(2));
+
+if (parsed.help) {
+  console.log(HELP_TEXT);
+  process.exit(0);
+}
+
+const { symbol, kind, params, options } = parsed;
+params.set('symbol', symbol);
+params.set('kind', kind);
+
+const url = new URL(options.path, options.base);
+url.search = params.toString();
+
+console.log(`[tiingo-cli] Requesting ${url}`);
+const req = new Request(url.toString());
+
+try {
+  const resp = await handleTiingoRequest(req);
+  const headers = Object.fromEntries(resp.headers.entries());
+  const bodyText = await resp.text();
+  let bodyOutput = bodyText;
+  if (!options.raw) {
+    try {
+      const parsedBody = JSON.parse(bodyText);
+      bodyOutput = JSON.stringify(parsedBody, null, 2);
+    } catch (error) {
+      bodyOutput = bodyText;
+    }
+  }
+
+  console.log('status', resp.status, resp.statusText || '');
+  console.log('headers', headers);
+  console.log(options.raw ? 'body' : 'body (formatted)', bodyOutput);
+} catch (error) {
+  console.error('[tiingo-cli] Request failed:', error);
+  process.exitCode = 1;
+}


### PR DESCRIPTION
## Summary
- add argument parsing, help text, and formatted output to `run-tiingo.mjs`
- update Tiingo implementation guide with new invocation example

## Testing
- node run-tiingo.mjs
- node run-tiingo.mjs MSFT intraday --limit=5

------
https://chatgpt.com/codex/tasks/task_e_68db4d195e78832993f8f6c9eff6a356