### PR TITLE
Align Netlify redirects with working config

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -46,16 +46,6 @@
 
 # SPA + Functions routing
 [[redirects]]
-  from = "/api/tiingo"
-  to = "/.netlify/functions/tiingo"
-  status = 200
-
-[[redirects]]
-  from = "/api/tiingo/*"
-  to = "/.netlify/functions/tiingo"
-  status = 200
-
-[[redirects]]
   from = "/api/*"
   to = "/.netlify/functions/:splat"
   status = 200


### PR DESCRIPTION
## Summary
- remove the Tiingo-specific redirect entries so the Netlify configuration matches the working netlifytrading setup

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68db53bfbf1883298abe0e28f9ed6de1